### PR TITLE
Derive Clone for bls::common::SigKey

### DIFF
--- a/bls/src/common.rs
+++ b/bls/src/common.rs
@@ -6,6 +6,7 @@ use amcl_wrapper::field_elem::FieldElement;
 use amcl_wrapper::group_elem::GroupElement;
 use amcl_wrapper::group_elem_g2::G2;
 
+#[derive(Clone)]
 pub struct SigKey {
     pub x: FieldElement
 }


### PR DESCRIPTION
Signed-off-by: Andrew J. Stone <andrew.j.stone.1@gmail.com>

I have another trivial fix to make keys Clone for you. Thanks!